### PR TITLE
Adjust width of assign control buttons.

### DIFF
--- a/src/actions/modal.js
+++ b/src/actions/modal.js
@@ -5,7 +5,7 @@ export const openModalAssign = (position, jobId, skillLineId) => {
   return {
     type: MODAL_OPEN,
     position,
-    width: 530,
+    width: 550,
     height: 400,
     content: 'assign',
     content_params: { jobId, skillLineId }

--- a/src/styles/skill-simulator/_input-modal.scss
+++ b/src/styles/skill-simulator/_input-modal.scss
@@ -45,7 +45,7 @@ $bulk-panel-padding: 5px;
   justify-content: space-around;
 
   &__controller {
-    width: 300px;
+    width: 329px;
     margin: 0;
     padding: 0;
   }
@@ -191,7 +191,8 @@ $bulk-panel-padding: 5px;
 
   &__assign-button {
     display: block;
-    width: 47px;
+    padding: 0;
+    width: 53px;
     height: $ui-panel-size;
     font-family: sans-serif;
     font-size: $ui-panel-font-size;


### PR DESCRIPTION
Word wraps occurred on "全消" and "全振" buttons with safari, iphone.